### PR TITLE
Firefox 41 disables the default (unreliable) STUN server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,7 @@ function getIPs(callback){
         optional: [{RtpDataChannels: true}]
     };
 
-    //firefox already has a default stun server in about:config
-    //    media.peerconnection.default_iceservers =
-    //    [{"url": "stun:stun.services.mozilla.com"}]
-    var servers = undefined;
-
-    //add same stun server for chrome
-    if(useWebKit)
-        servers = {iceServers: [{urls: "stun:stun.services.mozilla.com"}]};
+    var servers = {iceServers: [{urls: "stun:stun.services.mozilla.com"}]};
 
     //construct a new RTCPeerConnection
     var pc = new RTCPeerConnection(servers, mediaConstraints);

--- a/index.html
+++ b/index.html
@@ -52,14 +52,7 @@
                     optional: [{RtpDataChannels: true}]
                 };
 
-                //firefox already has a default stun server in about:config
-                //    media.peerconnection.default_iceservers =
-                //    [{"url": "stun:stun.services.mozilla.com"}]
-                var servers = undefined;
-
-                //add same stun server for chrome
-                if(useWebKit)
-                    servers = {iceServers: [{urls: "stun:stun.services.mozilla.com"}]};
+                var servers = {iceServers: [{urls: "stun:stun.services.mozilla.com"}]};
 
                 //construct a new RTCPeerConnection
                 var pc = new RTCPeerConnection(servers, mediaConstraints);


### PR DESCRIPTION
https://wiki.mozilla.org/Media/WebRTC/ReleaseNotes/41
