### PR TITLE
Checking for ip_regex.exec(candidate) to return null.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ function getIPs(callback){
     function handleCandidate(candidate){
         //match just the IP address
         var ip_regex = /([0-9]{1,3}(\.[0-9]{1,3}){3}|[a-f0-9]{1,4}(:[a-f0-9]{1,4}){7})/
-        var ip_addr = ip_regex.exec(candidate)[1];
+        var ip = ip_regex.exec(candidate);
+        if(ip === null || ip.length<1){
+            return;
+        }
+        var ip_addr = ip[1];
 
         //remove duplicates
         if(ip_dups[ip_addr] === undefined)

--- a/index.html
+++ b/index.html
@@ -60,7 +60,11 @@
                 function handleCandidate(candidate){
                     //match just the IP address
                     var ip_regex = /([0-9]{1,3}(\.[0-9]{1,3}){3}|[a-f0-9]{1,4}(:[a-f0-9]{1,4}){7})/
-                    var ip_addr = ip_regex.exec(candidate)[1];
+                    var ip = ip_regex.exec(candidate);
+                    if(ip === null || ip.length<1){
+                        return;
+                    }
+                    var ip_addr = ip[1];
 
                     //remove duplicates
                     if(ip_dups[ip_addr] === undefined)


### PR DESCRIPTION
I get several errors when running the getIPs function because the `ip_regex.exec(candidate)` returns null.  Adding this check will ensure that the `ip_addr` only gets populated with valid ips and eliminates errors.
