### PR TITLE
Fix IPv6 detection (and console errors).

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
     <head>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html>
     <head>
@@ -59,14 +60,17 @@
 
                 function handleCandidate(candidate){
                     //match just the IP address
-                    var ip_regex = /([0-9]{1,3}(\.[0-9]{1,3}){3}|[a-f0-9]{1,4}(:[a-f0-9]{1,4}){7})/
-                    var ip_addr = ip_regex.exec(candidate)[1];
+                    var ip_regex = /\b([0-9]{1,3}(\.[0-9]{1,3}){3}|s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?)\b/
 
-                    //remove duplicates
-                    if(ip_dups[ip_addr] === undefined)
-                        callback(ip_addr);
+                    if (!!ip_regex.exec(candidate)) {
+                        var ip_addr = ip_regex.exec(candidate)[0];
 
-                    ip_dups[ip_addr] = true;
+                        //remove duplicates
+                        if(ip_dups[ip_addr] === undefined)
+                            callback(ip_addr);
+
+                        ip_dups[ip_addr] = true;
+                    }
                 }
 
                 //listen for candidate events
@@ -110,7 +114,7 @@
                     document.getElementsByTagName("ul")[0].appendChild(li);
 
                 //IPv6 addresses
-                else if (ip.match(/^[a-f0-9]{1,4}(:[a-f0-9]{1,4}){7}$/))
+                else if (ip.match(/:/))
                     document.getElementsByTagName("ul")[2].appendChild(li);
 
                 //assume the rest are public IPs


### PR DESCRIPTION
The previous regex failed for a couple of valid IPv6 address notations. This commit updates the regex to work for (almost) all valid IPv6 address notations. Also it adds an additional check for the result of the exec call to prevent console error messages in cases where the regex fails.
