### PR TITLE
Add a mandatory parameter to createDataChannel()

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
                 };
 
                 //create a bogus data channel
-                pc.createDataChannel("");
+                pc.createDataChannel("rtc");
 
                 //create an offer sdp
                 pc.createOffer(function(result){


### PR DESCRIPTION
The createDataChannel() method now needs a Label parameter to work with the Unified Plan SDP format. It can't be blank and must have a value.

https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createDataChannel